### PR TITLE
Return some errors to the caller when setting async interrupt

### DIFF
--- a/src/gpio/interrupt.rs
+++ b/src/gpio/interrupt.rs
@@ -253,6 +253,7 @@ impl AsyncInterrupt {
     {
         let tx = EventFd::new()?;
         let rx = tx.fd();
+        let mut interrupt = Interrupt::new(fd, pin, trigger, debounce)?;
 
         let poll_thread = thread::spawn(move || -> Result<()> {
             let poll = Epoll::new()?;
@@ -260,7 +261,6 @@ impl AsyncInterrupt {
             // rx becomes readable when the main thread calls notify()
             poll.add(rx, rx as u64, EPOLLERR | EPOLLET | EPOLLIN)?;
 
-            let mut interrupt = Interrupt::new(fd, pin, trigger, debounce)?;
             poll.add(interrupt.fd(), interrupt.fd() as u64, EPOLLIN | EPOLLPRI)?;
 
             let mut events = [epoll_event { events: 0, u64: 0 }; 2];


### PR DESCRIPTION
If an error occurs while instantiating the Interrupt object inside the thread, it would be silenced and the thread would just quit without explicit notice; operations on the file descriptor (associated to the /dev/gpiochip0 device) can fail.
The Interrupt object can be instantiated before spawning the thread.