### PR TITLE
Implement AsRawFd trait for the Uart

### DIFF
--- a/src/uart.rs
+++ b/src/uart.rs
@@ -972,3 +972,9 @@ impl Uart {
         termios::flush(self.inner.fd, queue_type)
     }
 }
+
+impl AsRawFd for Uart {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.fd
+    }
+}


### PR DESCRIPTION
This is a very simple change that allows me to use the Uart with the `mio` crate for async I/O. There may be other/better ways.